### PR TITLE
config: fix declaration of theme on GitHub

### DIFF
--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -1,0 +1,3 @@
+# GitHub is not able to find this theme, so we have to split this configuration
+# out into a separate file.
+theme: type-on-strap

--- a/_config.yml
+++ b/_config.yml
@@ -14,5 +14,4 @@ footer_text: '<a href="/impressum">Impressum</a>, <a href="/datenschutz">Datensc
 excerpt: true
 post_navigation: true
 
-theme: type-on-strap
 remote_theme: sylhare/Type-on-Strap


### PR DESCRIPTION
GitHub complains about the "type-on-strap" theme not being found. This is because it parses both the "theme" and the "remote_theme" configs.

Fix this by splitting out the local theme into a separate config.