### PR TITLE
config: fix permalinks for recommendations and events

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,9 @@ collections:
     output: true
   events:
     output: true
+    permalink: /veranstaltungen/:name
   recommendations:
     output: true
+    permalink: /empfehlungen/:name
 
 remote_theme: sylhare/Type-on-Strap


### PR DESCRIPTION
The permalinks for recommendations and events are now using the name of the collection instead of the German variant thereof. Fix this by overriding the permalinks explicitly.